### PR TITLE
Fixing wrongly-cased overrides folder

### DIFF
--- a/curse.bash
+++ b/curse.bash
@@ -249,6 +249,15 @@ wget -O $TMP/tmp.zip "$URL" 2>&1 | \
 
 echo "0" | dialog --backtitle "$BACKTITLE" --title "Preparing files" --gauge "Please wait" 10 100
 unzip $TMP/tmp.zip -d $TMP/modpack > /dev/null 2>&1
+
+# Fix overrides folder - some packs contains wrongly cased one
+
+overdir=$(/bin/ls -1 "$TMP/modpack/" | grep -i overrides | head -n1)
+
+if [ "$overdir" != "overrides" ]; then
+  mv "${TMP}/modpack/${overdir}" "${TMP}/modpack/overrides"
+fi
+
 echo "100" | dialog --backtitle "$BACKTITLE" --title "Preparing files" --gauge "Please wait" 10 100
 
 FILE=$TMP/modpack/manifest.json


### PR DESCRIPTION
Some modpacks (for example [this one](http://www.curse.com/modpacks/minecraft/233600-botanical-ascension)) contains a wrongly-cased `overrides` folder - this is normal, as most modpacks are coming from Windows that is case-insensitive.

The patch is fixes the casing to match the expected casing for downloading mods and making a modpack in MultiMC.
